### PR TITLE
Fix: Configure Netlify for SPA client-side routing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,8 @@
   command = "npm run build"
   publish = "dist"
 
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
 


### PR DESCRIPTION
I've added a redirect rule to `netlify.toml` to ensure all paths are served by `index.html`. This allows client-side routing (e.g., React Router) to handle navigation within the single-page application and resolves 404 errors on direct navigation or refresh to sub-paths.